### PR TITLE
Implement TCP-like reliable messaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ all: $(CHALLENGE_EXECS)
 $(BUILD_DIR)/challenge-1.out: $(CHALLENGE_1_OBJS) $(BUILD_DIR)/util.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
-$(BUILD_DIR)/challenge-2.out: $(CHALLENGE_2_OBJS) $(BUILD_DIR)/util.o $(BUILD_DIR)/collections.o
+$(BUILD_DIR)/challenge-2.out: $(CHALLENGE_2_OBJS) $(BUILD_DIR)/util.o $(BUILD_DIR)/collections.o $(BUILD_DIR)/tcp.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
 $(BUILD_DIR)/challenge-1.o: $(CHALLENGE_1_SRC) $(LIB_DIR)/util.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(BUILD_DIR)/challenge-2.o: $(CHALLENGE_2_SRC) $(LIB_DIR)/util.h $(LIB_DIR)/collections.h
+$(BUILD_DIR)/challenge-2.o: $(CHALLENGE_2_SRC) $(LIB_DIR)/util.h $(LIB_DIR)/collections.h $(LIB_DIR)/tcp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # Generate object files for library modules
@@ -60,6 +60,9 @@ $(BUILD_DIR)/vec_deque_tests.o: $(VEC_DEQUE_TEST_SRC) $(LIB_DIR)/vec_deque.h
 .PHONY: tests
 tests: $(BUILD_DIR)/vec_deque_tests.out
 	valgrind --leak-check=full ./$(BUILD_DIR)/vec_deque_tests.out
+
+$(BUILD_DIR)/tcp.o: $(LIB_DIR)/tcp.c $(LIB_DIR)/tcp.h
+	$(CC) $(CFLAGS) -c $< -o $@
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: $(CHALLENGE_EXECS)
 $(BUILD_DIR)/challenge-1.out: $(CHALLENGE_1_OBJS) $(BUILD_DIR)/util.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
-$(BUILD_DIR)/challenge-2.out: $(CHALLENGE_2_OBJS) $(BUILD_DIR)/util.o $(BUILD_DIR)/collections.o $(BUILD_DIR)/tcp.o
+$(BUILD_DIR)/challenge-2.out: $(CHALLENGE_2_OBJS) $(BUILD_DIR)/util.o $(BUILD_DIR)/collections.o $(BUILD_DIR)/tcp.o $(BUILD_DIR)/stopwatch.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
 $(BUILD_DIR)/challenge-1.o: $(CHALLENGE_1_SRC) $(LIB_DIR)/util.h
@@ -34,7 +34,7 @@ $(BUILD_DIR)/challenge-2.o: $(CHALLENGE_2_SRC) $(LIB_DIR)/util.h $(LIB_DIR)/coll
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # TODO(kevan): clean this up before committing.
-$(BUILD_DIR)/tcp-test.out: $(BUILD_DIR)/tcp-test.o $(BUILD_DIR)/util.o $(BUILD_DIR)/tcp.o $(BUILD_DIR)/collections.o
+$(BUILD_DIR)/tcp-test.out: $(BUILD_DIR)/tcp-test.o $(BUILD_DIR)/util.o $(BUILD_DIR)/tcp.o $(BUILD_DIR)/collections.o $(BUILD_DIR)/stopwatch.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 $(BUILD_DIR)/tcp-test.o: tests/lib/tcp-test.c $(LIB_DIR)/util.h $(LIB_DIR)/tcp.h
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -67,7 +67,10 @@ $(BUILD_DIR)/vec_deque_tests.o: $(VEC_DEQUE_TEST_SRC) $(LIB_DIR)/vec_deque.h
 tests: $(BUILD_DIR)/vec_deque_tests.out
 	valgrind --leak-check=full ./$(BUILD_DIR)/vec_deque_tests.out
 
-$(BUILD_DIR)/tcp.o: $(LIB_DIR)/tcp.c $(LIB_DIR)/tcp.h
+$(BUILD_DIR)/tcp.o: $(LIB_DIR)/tcp.c $(LIB_DIR)/tcp.h $(LIB_DIR)/stopwatch.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/stopwatch.o: $(LIB_DIR)/stopwatch.c $(LIB_DIR)/stopwatch.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ $(BUILD_DIR)/challenge-1.o: $(CHALLENGE_1_SRC) $(LIB_DIR)/util.h
 $(BUILD_DIR)/challenge-2.o: $(CHALLENGE_2_SRC) $(LIB_DIR)/util.h $(LIB_DIR)/collections.h $(LIB_DIR)/tcp.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# TODO(kevan): clean this up before committing.
+$(BUILD_DIR)/tcp-test.out: $(BUILD_DIR)/tcp-test.o $(BUILD_DIR)/util.o $(BUILD_DIR)/tcp.o $(BUILD_DIR)/collections.o
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
+$(BUILD_DIR)/tcp-test.o: tests/lib/tcp-test.c $(LIB_DIR)/util.h $(LIB_DIR)/tcp.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
 # Generate object files for library modules
 $(BUILD_DIR)/util.o: $(LIB_DIR)/util.c $(LIB_DIR)/util.h
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -6,7 +6,6 @@
 
 #define INITIAL_LIST_MAX_LENGTH 16
 #define INITIAL_DICTIONARY_MAX_LENGTH 16
-#define KEY_NOT_FOUND -1
 #define FNV_OFFSET 14695981039346656037UL
 #define FNV_PRIME 1099511628211UL
 
@@ -288,6 +287,12 @@ typedef struct Dictionary
     size_t length;
 } Dictionary;
 
+typedef struct DictionaryLookupResult
+{
+    bool found;
+    size_t index;
+} DictionaryLookupResult;
+
 Dictionary* dictionary_init(void)
 {
     Dictionary* dictionary = malloc(sizeof(Dictionary));
@@ -308,23 +313,25 @@ Dictionary* dictionary_init(void)
     return dictionary;
 }
 
-static ssize_t dictionary_lookup(Dictionary* dictionary, const char* key)
+static DictionaryLookupResult dictionary_lookup(Dictionary* dictionary,
+                                                const char* key)
 {
-    ssize_t index = hash_key(key) % dictionary->max_length;
+    size_t index = hash_key(key) % dictionary->max_length;
     while (dictionary->key_value_pairs[index].key != NULL)
     {
         if (strcmp(dictionary->key_value_pairs[index].key, key) == 0)
         {
-            return index;
+            return (DictionaryLookupResult){true, index};
         }
         index = (index + 1) % dictionary->max_length;
     }
-    return KEY_NOT_FOUND;
+    return (DictionaryLookupResult){false, index};
 }
 
 bool dictionary_contains(Dictionary* dictionary, const char* key)
 {
-    return dictionary_lookup(dictionary, key) != KEY_NOT_FOUND;
+    DictionaryLookupResult lookup_result = dictionary_lookup(dictionary, key);
+    return lookup_result.found;
 }
 
 static void dictionary_rebuild(Dictionary* dictionary)
@@ -372,9 +379,9 @@ static void dictionary_rebuild(Dictionary* dictionary)
 
 void dictionary_set(Dictionary* dictionary, const char* key, void* value)
 {
-    ssize_t index = dictionary_lookup(dictionary, key);
+    DictionaryLookupResult lookup_result = dictionary_lookup(dictionary, key);
     // Key does not exist, add new KeyValuePair
-    if (index == KEY_NOT_FOUND)
+    if (!lookup_result.found)
     {
         char* copied_key = key ? strdup(key) : NULL;
         if (copied_key == NULL)
@@ -389,27 +396,27 @@ void dictionary_set(Dictionary* dictionary, const char* key, void* value)
             exit(EXIT_FAILURE);
         }
         KeyValuePair key_value_pair = {copied_key, value};
-        dictionary_rebuild(dictionary);
-        index = dictionary_lookup(dictionary, key);
-        dictionary->key_value_pairs[index] = key_value_pair;
+        dictionary->key_value_pairs[lookup_result.index] = key_value_pair;
         dictionary->length++;
+        dictionary_rebuild(dictionary);
     }
     // Key already exists, just replace value (no need to free the key)
     else
     {
-        free(dictionary->key_value_pairs[index].value);
-        dictionary->key_value_pairs[index].value = value;
+        // FIX: Leaked underlying queue in the ChannelState value
+        free(dictionary->key_value_pairs[lookup_result.index].value);
+        dictionary->key_value_pairs[lookup_result.index].value = value;
         return;
     }
 }
 
 void* dictionary_get(Dictionary* dictionary, const char* key)
 {
-    ssize_t index = dictionary_lookup(dictionary, key);
+    DictionaryLookupResult lookup_result = dictionary_lookup(dictionary, key);
     // Key successfully found, return value
-    if (index != KEY_NOT_FOUND)
+    if (lookup_result.found)
     {
-        return dictionary->key_value_pairs[index].value;
+        return dictionary->key_value_pairs[lookup_result.index].value;
     }
     // Raise error if key not found
     else

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -272,6 +272,8 @@ typedef struct Dictionary
     size_t length;
 } Dictionary;
 
+// TODO: Abstract out linear probing function
+// lookup_key(char *key) -> index or -1 if not found
 Dictionary* dictionary_init(void)
 {
     Dictionary* dictionary = malloc(sizeof(Dictionary));

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -405,8 +405,8 @@ void dictionary_set(Dictionary* dictionary, const char* key, void* value)
     // Key already exists, just replace value (no need to free the key)
     else
     {
-        // FIX: Leaked underlying queue in the ChannelState value
-        dictionary->elem_free(dictionary->key_value_pairs[lookup_result.index].value);
+        dictionary->elem_free(
+            dictionary->key_value_pairs[lookup_result.index].value);
         dictionary->key_value_pairs[lookup_result.index].value = value;
         return;
     }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -30,13 +30,14 @@ typedef struct Queue
     Node* tail;
     size_t length;
     size_t max_length;
+    void (*free_function)(void*);
 } Queue;
 
 bool queue_is_full(Queue* queue) { return queue->length == queue->max_length; }
 
 bool queue_is_empty(Queue* queue) { return queue->length == 0; }
 
-Queue* queue_init(size_t max_length)
+Queue* queue_init(size_t max_length, void (*free_function)(void*))
 {
     Queue* queue = malloc(sizeof(Queue));
     if (queue == NULL)
@@ -48,6 +49,7 @@ Queue* queue_init(size_t max_length)
     queue->length = 0;
     queue->head = NULL;
     queue->tail = NULL;
+    queue->free_function = free_function;
     return queue;
 }
 
@@ -109,7 +111,9 @@ void queue_free(Queue* queue)
     while (!queue_is_empty(queue))
     {
         void* data = queue_dequeue(queue);
-        free(data);
+        if (queue->free_function) {
+            queue->free_function(data);
+        }
     }
     free(queue);
 }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -50,6 +50,16 @@ Queue* queue_init(size_t max_length)
     return queue;
 }
 
+void* queue_peek(Queue* queue)
+{
+    if (!queue_is_empty(queue))
+    {
+        return queue->head->data;
+    }
+    fprintf(stderr, "Error: queue_peek: queue is empty\n");
+    exit(EXIT_FAILURE);
+}
+
 void queue_enqueue(Queue* queue, void* data)
 {
     if (queue_is_full(queue))

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -6,6 +6,7 @@
 
 #define INITIAL_LIST_MAX_LENGTH 16
 #define INITIAL_DICTIONARY_MAX_LENGTH 16
+#define KEY_NOT_FOUND -1
 #define FNV_OFFSET 14695981039346656037UL
 #define FNV_PRIME 1099511628211UL
 
@@ -282,8 +283,6 @@ typedef struct Dictionary
     size_t length;
 } Dictionary;
 
-// TODO: Abstract out linear probing function
-// lookup_key(char *key) -> index or -1 if not found
 Dictionary* dictionary_init(void)
 {
     Dictionary* dictionary = malloc(sizeof(Dictionary));
@@ -315,12 +314,12 @@ static uint64_t dictionary_lookup(Dictionary* dictionary, const char* key)
         }
         index = (index + 1) % dictionary->max_length;
     }
-    return -1;
+    return KEY_NOT_FOUND;
 }
 
 bool dictionary_contains(Dictionary* dictionary, const char* key)
 {
-    return dictionary_lookup(dictionary, key) != -1;
+    return dictionary_lookup(dictionary, key) != KEY_NOT_FOUND;
 }
 
 static void dictionary_rebuild(Dictionary* dictionary)
@@ -370,7 +369,7 @@ void dictionary_set(Dictionary* dictionary, const char* key, void* value)
 {
     uint64_t index = dictionary_lookup(dictionary, key);
     // Key does not exist, add new KeyValuePair
-    if (index == -1)
+    if (index == KEY_NOT_FOUND)
     {
         char* copied_key = key ? strdup(key) : NULL;
         if (copied_key == NULL)
@@ -403,7 +402,7 @@ void* dictionary_get(Dictionary* dictionary, const char* key)
 {
     uint64_t index = dictionary_lookup(dictionary, key);
     // Key successfully found, return value
-    if (index != -1)
+    if (index != KEY_NOT_FOUND)
     {
         return dictionary->key_value_pairs[index].value;
     }

--- a/lib/collections.c
+++ b/lib/collections.c
@@ -111,7 +111,8 @@ void queue_free(Queue* queue)
     while (!queue_is_empty(queue))
     {
         void* data = queue_dequeue(queue);
-        if (queue->free_function) {
+        if (queue->free_function)
+        {
             queue->free_function(data);
         }
     }
@@ -307,9 +308,9 @@ Dictionary* dictionary_init(void)
     return dictionary;
 }
 
-static uint64_t dictionary_lookup(Dictionary* dictionary, const char* key)
+static ssize_t dictionary_lookup(Dictionary* dictionary, const char* key)
 {
-    uint64_t index = hash_key(key) % dictionary->max_length;
+    ssize_t index = hash_key(key) % dictionary->max_length;
     while (dictionary->key_value_pairs[index].key != NULL)
     {
         if (strcmp(dictionary->key_value_pairs[index].key, key) == 0)
@@ -371,7 +372,7 @@ static void dictionary_rebuild(Dictionary* dictionary)
 
 void dictionary_set(Dictionary* dictionary, const char* key, void* value)
 {
-    uint64_t index = dictionary_lookup(dictionary, key);
+    ssize_t index = dictionary_lookup(dictionary, key);
     // Key does not exist, add new KeyValuePair
     if (index == KEY_NOT_FOUND)
     {
@@ -404,7 +405,7 @@ void dictionary_set(Dictionary* dictionary, const char* key, void* value)
 
 void* dictionary_get(Dictionary* dictionary, const char* key)
 {
-    uint64_t index = dictionary_lookup(dictionary, key);
+    ssize_t index = dictionary_lookup(dictionary, key);
     // Key successfully found, return value
     if (index != KEY_NOT_FOUND)
     {

--- a/lib/collections.h
+++ b/lib/collections.h
@@ -12,6 +12,7 @@ typedef struct Dictionary Dictionary;
 Queue* queue_init(size_t size);
 void queue_enqueue(Queue* queue, void* data);
 void* queue_dequeue(Queue* queue);
+void* queue_peek(Queue* queue);
 bool queue_is_full(Queue* queue);
 bool queue_is_empty(Queue* queue);
 void queue_free(Queue* queue);

--- a/lib/collections.h
+++ b/lib/collections.h
@@ -9,13 +9,29 @@ typedef struct Conch Conch;
 typedef struct List List;
 typedef struct Dictionary Dictionary;
 
-Queue* queue_init(size_t size);
+// Returns an owned `Queue`.
+Queue* queue_init(size_t max_length, void (*free_function)(void*));
+
+// Borrows `queue`. Takes ownership of `data`.
 void queue_enqueue(Queue* queue, void* data);
+
+// Borrows `queue`. Returns an owned pointer.
 void* queue_dequeue(Queue* queue);
+
+// Borrows `queue`. Returned pointer is borrowed from `queue`.
 void* queue_peek(Queue* queue);
+
+// Borrows `queue`.
 bool queue_is_full(Queue* queue);
+
+// Borrows `queue`.
 bool queue_is_empty(Queue* queue);
+
+// Takes ownership of `queue`.
 void queue_free(Queue* queue);
+
+
+
 
 Conch* conch_init(int64_t initial_conch_value);
 void conch_checkin(Conch* conch, int64_t new_conch_value);

--- a/lib/collections.h
+++ b/lib/collections.h
@@ -47,7 +47,7 @@ void list_set_at(List* list, size_t index, void* data);
 size_t list_length(List* list);
 void list_free(List* list);
 
-Dictionary* dictionary_init(void);
+Dictionary* dictionary_init(void (*elem_free)(void*));
 void dictionary_set(Dictionary* dictionary, const char* key, void* value);
 void* dictionary_get(Dictionary* dictionary, const char* key);
 bool dictionary_contains(Dictionary* dictionary, const char* key);

--- a/lib/stopwatch.c
+++ b/lib/stopwatch.c
@@ -1,0 +1,13 @@
+#include "stopwatch.h"
+#include <time.h>
+
+// Function to calculate the time difference between two timespec values in
+// milliseconds
+long long timespec_diff_ms(struct timespec* start, struct timespec* end)
+{
+    long long diff_sec = (long long)(end->tv_sec - start->tv_sec);
+    long long diff_nsec = (long long)(end->tv_nsec - start->tv_nsec);
+
+    // Convert nanoseconds to milliseconds and add to seconds
+    return diff_sec * 1000LL + diff_nsec / 1000000LL;
+}

--- a/lib/stopwatch.h
+++ b/lib/stopwatch.h
@@ -1,3 +1,8 @@
 #include <time.h>
 
+#define DEFAULT_TIMEOUT_TIMEVAL                                                \
+    {                                                                          \
+        .tv_sec = 1, .tv_usec = 0                                              \
+    }
+
 long long timespec_diff_ms(struct timespec* start, struct timespec* end);

--- a/lib/stopwatch.h
+++ b/lib/stopwatch.h
@@ -1,8 +1,3 @@
 #include <time.h>
 
-#define DEFAULT_TIMEOUT_TIMEVAL                                                \
-    {                                                                          \
-        .tv_sec = 1, .tv_usec = 0                                              \
-    }
-
 long long timespec_diff_ms(struct timespec* start, struct timespec* end);

--- a/lib/stopwatch.h
+++ b/lib/stopwatch.h
@@ -1,0 +1,3 @@
+#include <time.h>
+
+long long timespec_diff_ms(struct timespec* start, struct timespec* end);

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -124,6 +124,8 @@ json_object* msg_recv_listener()
             {
                 Message* m = queue_peek(channel_state->send_queue);
                 json_object_get(m->msg);
+                fprintf(stderr, "(send) msg: %s\n",
+                        json_object_to_json_string(m->msg));
                 msg_send(m->msg);
             }
         }

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -82,8 +82,6 @@ void tcp_free(void)
     }
     for (size_t i = 0; i < NUM_PEERS; i++)
     {
-        ChannelState* channel_state = dictionary_get(CHANNEL_STATES, PEERS[i]);
-        queue_free(channel_state->send_queue);
         free(PEERS[i]);
     }
     free(PEERS);

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -1,0 +1,70 @@
+#include "tcp.h"
+#include "collections.h"
+#include "json-c/json_object.h"
+#include "util.h"
+#include <stdint.h>
+#include <string.h>
+
+typedef struct ChannelState
+{
+    // Send state
+    Queue* send_queue;
+    uint64_t next_send_msg_seq_index;
+    // Receive state
+    uint64_t last_recv_msg_seq_index;
+} ChannelState;
+
+typedef struct Message
+{
+    uint64_t msg_seq_index;
+    json_object* msg;
+} Message;
+
+ChannelState CHANNEL_STATE = {NULL, 0, -1};
+
+void msg_send_pusher(json_object* msg)
+{
+    if (CHANNEL_STATE.send_queue == NULL)
+    {
+        CHANNEL_STATE.send_queue = queue_init(100);
+    }
+    Message* m = malloc(sizeof(Message));
+    m->msg_seq_index = CHANNEL_STATE.next_send_msg_seq_index++;
+    json_object_object_add(msg, "seq_msg_index",
+                           json_object_new_uint64(m->msg_seq_index));
+    m->msg = msg;
+    queue_enqueue(CHANNEL_STATE.send_queue, m);
+}
+
+json_object* msg_recv_listener()
+{
+    while (true)
+    {
+        json_object* m = msg_recv();
+        if (m == NULL)
+        {
+            return m;
+        }
+        // TODO: decide if m is a data message
+        json_object* body = json_object_object_get(m, "body");
+        json_object* type = json_object_object_get(body, "type");
+        if (strcmp(json_object_get_string(type), "ACK") == 0 &&
+            !queue_is_empty(CHANNEL_STATE.send_queue))
+        {
+            uint64_t ack_seq_msg_index = json_object_get_uint64(
+                json_object_object_get(body, "seq_msg_index"));
+            uint64_t head_seq_msg_index =
+                ((Message*)queue_peek(CHANNEL_STATE.send_queue))->msg_seq_index;
+            if (head_seq_msg_index == ack_seq_msg_index)
+            {
+                free(queue_dequeue(CHANNEL_STATE.send_queue));
+            }
+        }
+        else
+        {
+            // TODO: Send ACK message back to R
+            json_object* ack_msg = generate_ACK_msg(m);
+            msg_send(ack_msg);
+        }
+    }
+}

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -100,13 +100,10 @@ static json_object* generate_ACK_msg(json_object* msg)
 
 void msg_send_pusher(json_object* msg)
 {
-    fprintf(stderr, "(msg_send_pusher) start\n");
     const char* peer =
         json_object_get_string(json_object_object_get(msg, "dest"));
     Message* m = malloc(sizeof(Message));
-    fprintf(stderr, "(push) before get. peer: %s\n", peer);
     ChannelState* channel_state = dictionary_get(CHANNEL_STATES, peer);
-    fprintf(stderr, "(push) after get\n");
     m->msg_seq_index = channel_state->next_send_msg_seq_index++;
     json_object* body = json_object_object_get(msg, "body");
     json_object_object_add(body, "seq_msg_index",
@@ -127,8 +124,6 @@ json_object* msg_recv_listener()
             {
                 Message* m = queue_peek(channel_state->send_queue);
                 json_object_get(m->msg);
-                fprintf(stderr, "(send) msg: %s\n",
-                        json_object_to_json_string(m->msg));
                 msg_send(m->msg);
             }
         }
@@ -140,17 +135,12 @@ json_object* msg_recv_listener()
         }
 
         // Client messages; no need to ACK these.
-        const char* src =
-            json_object_get_string(json_object_object_get(m, "src"));
-        fprintf(stderr, "(listen) src: %s\n", src);
+        const char* src = json_object_get_string(json_object_object_get(m, "src"));
         if (!dictionary_contains(CHANNEL_STATES, src))
         {
             return m;
         }
-
-        fprintf(stderr, "(listen) before get. src: %s\n", src);
         ChannelState* channel_state = dictionary_get(CHANNEL_STATES, src);
-        fprintf(stderr, "(listen) after get\n");
         json_object* body = json_object_object_get(m, "body");
         json_object* type = json_object_object_get(body, "type");
 

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -4,12 +4,14 @@
 #include "util.h"
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define MAX_SEND_QUEUE_SIZE 100
 #define INITIAL_SEND_MSG_SEQ_INDEX 0
 #define INITIAL_RECV_MSG_SEQ_INDEX 0
+
+// FIX: Duplicate data messages being sent from node to itself
 
 typedef struct ChannelState
 {
@@ -49,7 +51,7 @@ void channel_state_free(ChannelState* channel_state)
     free(channel_state);
 }
 
-void channel_state_free_void(void* channel_state) 
+void channel_state_free_void(void* channel_state)
 {
     channel_state_free(channel_state);
 }

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -142,6 +142,7 @@ json_object* msg_recv_listener()
             }
         }
 
+        // TODO: Handle multiple cases (including timeouts) here
         json_object* m = msg_recv();
         if (m == NULL)
         {

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -12,7 +12,7 @@
 #define MAX_SEND_QUEUE_SIZE 100
 #define INITIAL_SEND_MSG_SEQ_INDEX 0
 #define INITIAL_RECV_MSG_SEQ_INDEX 0
-#define MSG_SEND_TIMEOUT_MS 1000
+#define MSG_SEND_TIMEOUT_MS 100
 
 typedef struct ChannelState
 {

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -4,8 +4,8 @@
 #include "util.h"
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define MAX_SEND_QUEUE_SIZE 100
 #define INITIAL_SEND_MSG_SEQ_INDEX 0
@@ -49,7 +49,7 @@ void channel_state_free(ChannelState* channel_state)
     free(channel_state);
 }
 
-void channel_state_free_void(void* channel_state)
+void channel_state_free_void(void* channel_state) 
 {
     channel_state_free(channel_state);
 }

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define MAX_SEND_QUEUE_SIZE 100
 #define INITIAL_SEND_MSG_SEQ_INDEX 0
@@ -42,9 +43,20 @@ ChannelState* channel_state_init()
     return channel_state;
 }
 
+void channel_state_free(ChannelState* channel_state)
+{
+    queue_free(channel_state->send_queue);
+    free(channel_state);
+}
+
+void channel_state_free_void(void* channel_state) 
+{
+    channel_state_free(channel_state);
+}
+
 void tcp_init(const char** peers, const size_t num_peers)
 {
-    CHANNEL_STATES = dictionary_init();
+    CHANNEL_STATES = dictionary_init(channel_state_free_void);
     PEERS = malloc(num_peers * sizeof(char*));
     for (size_t i = 0; i < num_peers; i++)
     {

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -106,7 +106,8 @@ void msg_send_pusher(json_object* msg)
     ChannelState* channel_state = dictionary_get(CHANNEL_STATES, peer);
     fprintf(stderr, "(push) after get\n");
     m->msg_seq_index = channel_state->next_send_msg_seq_index++;
-    json_object_object_add(msg, "seq_msg_index",
+    json_object* body = json_object_object_get(msg, "body");
+    json_object_object_add(body, "seq_msg_index",
                            json_object_new_uint64(m->msg_seq_index));
     m->msg = msg;
     queue_enqueue(channel_state->send_queue, m);

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -4,8 +4,8 @@
 #include "util.h"
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define MAX_SEND_QUEUE_SIZE 100
 #define INITIAL_SEND_MSG_SEQ_INDEX 0
@@ -49,7 +49,7 @@ void channel_state_free(ChannelState* channel_state)
     free(channel_state);
 }
 
-void channel_state_free_void(void* channel_state) 
+void channel_state_free_void(void* channel_state)
 {
     channel_state_free(channel_state);
 }
@@ -153,10 +153,12 @@ json_object* msg_recv_listener()
         json_object* type = json_object_object_get(body, "type");
 
         // Case: Received an ACK
-        if (strcmp(json_object_get_string(type), "ACK") == 0 &&
-            // NOTE: KH is concerned about spurious ACKs when the queue is empty
-            !queue_is_empty(channel_state->send_queue))
+        if (strcmp(json_object_get_string(type), "ACK") == 0)
         {
+            if (queue_is_empty(channel_state->send_queue))
+            {
+                continue;
+            }
             uint64_t ack_seq_msg_index = json_object_get_uint64(
                 json_object_object_get(body, "seq_msg_index"));
             uint64_t head_seq_msg_index =

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -140,7 +140,6 @@ json_object* msg_recv_listener()
             }
         }
 
-        // TODO: Handle multiple cases (including timeouts) here
         json_object* m = msg_recv();
         if (m == NULL)
         {

--- a/lib/tcp.h
+++ b/lib/tcp.h
@@ -5,3 +5,6 @@
 void msg_send_pusher(json_object* msg);
 
 json_object* msg_recv_listener();
+
+void tcp_init(const char** peers, const size_t num_peers);
+void tcp_free(const char** peers, const size_t num_peers);

--- a/lib/tcp.h
+++ b/lib/tcp.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <json-c/json.h>
+
+void msg_send_pusher(json_object* msg);
+
+json_object* msg_recv_listener();

--- a/lib/tcp.h
+++ b/lib/tcp.h
@@ -11,5 +11,4 @@ json_object* msg_recv_listener();
 // Borrows `peers`.
 void tcp_init(const char** peers, const size_t num_peers);
 
-// Borrows `peers`.
-void tcp_free(const char** peers, const size_t num_peers);
+void tcp_free(void);

--- a/lib/tcp.h
+++ b/lib/tcp.h
@@ -2,9 +2,14 @@
 
 #include <json-c/json.h>
 
+// Takes ownership of `msg`.
 void msg_send_pusher(json_object* msg);
 
+// Returns an owned object (or NULL).
 json_object* msg_recv_listener();
 
+// Borrows `peers`.
 void tcp_init(const char** peers, const size_t num_peers);
+
+// Borrows `peers`.
 void tcp_free(const char** peers, const size_t num_peers);

--- a/lib/util.c
+++ b/lib/util.c
@@ -9,6 +9,13 @@
 
 void msg_send(json_object* msg)
 {
+    static uint64_t reply_msg_id = 0;
+
+    // Add a unique msg id to the reply.
+    json_object* reply_body = json_object_object_get(msg, "body");
+    json_object_object_add(reply_body, "msg_id",
+                           json_object_new_int64(reply_msg_id++));
+
     printf("%s\n", json_object_to_json_string(msg));
     fflush(stdout);
     json_object_put(msg);
@@ -48,8 +55,6 @@ json_object* msg_recv()
     return msg;
 }
 
-uint64_t REPLY_MSG_ID = 0;
-
 json_object* generic_reply(json_object* msg)
 {
     json_object* reply = json_object_new_object();
@@ -80,11 +85,6 @@ json_object* generic_reply(json_object* msg)
     strcpy(&(new_name[n]), "_ok");
     json_object* reply_type = json_object_new_string(new_name);
     json_object_object_add(reply_body, "type", reply_type);
-
-    // Add a unique msg id to the reply.
-    uint64_t msg_id = REPLY_MSG_ID++;
-    json_object* reply_msg_id = json_object_new_int64(msg_id);
-    json_object_object_add(reply_body, "msg_id", reply_msg_id);
 
     return reply;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -21,28 +21,60 @@ void msg_send(json_object* msg)
     json_object_put(msg);
 }
 
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/select.h>
+#include <stdio.h>
+#include <unistd.h>
+
+ssize_t getline_with_timeout(
+    char** input_line,
+    size_t* input_len,
+    struct timeval timeout,
+) {
+    fd_set set;
+    FD_ZERO(&set); /* clear the set */
+    FD_SET(STDIN_FILENO, &set); /* add our file descriptor to the set */
+    int buffer_state;
+
+    buffer_state = select(1, &set, NULL, NULL, &timeout);
+
+
+    if(buffer_state == -1) {
+        fprintf(stderr, "Error: select in getline_with_timeout failed\n");
+        exit(EXIT_FAILURE);
+    } else if(buffer_state == 0) {
+        return -1;
+    } else {
+        errno = 0;
+        ssize_t input_read = getline(input_line, input_len, stdin);
+        if (input_read == -1)
+        {
+            // End of stdin; return NULL.
+            if (errno == 0)
+            {
+                free(input_line);
+                return NULL;
+            }
+
+            // IO error.
+            perror("getline");
+            free(input_line);
+            exit(EXIT_FAILURE);
+        }
+
+    }
+}
+
 json_object* msg_recv()
 {
     char* input_line = NULL;
     size_t input_len = 0;
 
     errno = 0;
-    ssize_t input_bytes_read = getline(&input_line, &input_len, stdin);
-    if (input_bytes_read == -1)
-    {
-        // End of stdin; return NULL.
-        if (errno == 0)
-        {
-            free(input_line);
-            return NULL;
-        }
-
-        // IO error.
-        perror("getline");
-        free(input_line);
-        exit(EXIT_FAILURE);
-    }
-
+    ssize_t input_bytes_read = getline_with_timeout(&input_line, &input_len);
     json_object* msg = json_tokener_parse(input_line);
     if (msg == NULL)
     {

--- a/lib/util.c
+++ b/lib/util.c
@@ -73,9 +73,7 @@ json_object* generic_reply(json_object* msg)
     json_object_object_add(reply_body, "in_reply_to", reply_in_reply_to);
 
     // Generate reply type: "XXX_ok"
-    json_object* type =
-        json_object_object_get(json_object_object_get(msg, "body"), "type");
-    const char* name = json_object_get_string(type);
+    const char* name = msg_type(msg);
     size_t n = strlen(name);
     char new_name[n + 4]; // +4 for "_ok" and null terminator.
     strcpy(new_name, name);
@@ -122,7 +120,7 @@ const char** node_ids(json_object* init_msg)
     return peers;
 }
 
-const size_t node_ids_count(json_object* init_msg)
+size_t node_ids_count(json_object* init_msg)
 {
     json_object* body = json_object_object_get(init_msg, "body");
     json_object* node_ids = json_object_object_get(body, "node_ids");

--- a/lib/util.c
+++ b/lib/util.c
@@ -23,15 +23,16 @@ void msg_send(json_object* msg)
     json_object_put(msg);
 }
 
-long long getline_with_timeout(char** input_line, size_t* input_len,
-                               struct timeval timeout)
+getline_result_t getline_with_timeout(struct timeval* timeout)
 {
+    getline_result_t result;
+
     fd_set set;
     FD_ZERO(&set);              /* clear the set */
     FD_SET(STDIN_FILENO, &set); /* add our file descriptor to the set */
     int buffer_state;
 
-    buffer_state = select(1, &set, NULL, NULL, &timeout);
+    buffer_state = select(1, &set, NULL, NULL, timeout);
 
     if (buffer_state == -1)
     {
@@ -40,19 +41,23 @@ long long getline_with_timeout(char** input_line, size_t* input_len,
     }
     else if (buffer_state == 0)
     {
-        return INPUT_READ_TIMEDOUT;
+        result.result = INPUT_READ_TIMEDOUT;
+        return result;
     }
     else
     {
         errno = 0;
-        ssize_t input_bytes_read = getline(input_line, input_len, stdin);
+        char* input_line = NULL;
+        size_t input_len = 0;
+        ssize_t input_bytes_read = getline(&input_line, &input_len, stdin);
         if (input_bytes_read == -1)
         {
             // End of STDIN
             if (errno == 0)
             {
                 free(input_line);
-                return INPUT_READ_EOF;
+                result.result = INPUT_READ_EOF;
+                return result;
             }
 
             // IO error
@@ -62,42 +67,81 @@ long long getline_with_timeout(char** input_line, size_t* input_len,
         }
         else
         {
-            return (long long)input_bytes_read;
+            result.result = INPUT_READ_SUCCESS;
+            result.line = input_line;
+            result.line_len = input_len;
+            return result;
+        }
+    }
+}
+
+msg_recv_result_t msg_recv_with_timeout(struct timeval* timeout)
+{
+    msg_recv_result_t msg_result;
+    getline_result_t line_result = getline_with_timeout(timeout);
+    switch (line_result.result)
+    {
+        case (INPUT_READ_EOF):
+        {
+            msg_result.result = INPUT_READ_EOF;
+            return msg_result;
+        }
+        case (INPUT_READ_TIMEDOUT):
+        {
+            msg_result.result = INPUT_READ_TIMEDOUT;
+            return msg_result;
+        }
+        case (INPUT_READ_SUCCESS):
+        {
+            json_object* msg = json_tokener_parse(line_result.line);
+            if (msg == NULL)
+            {
+                fprintf(stderr, "Error: msg_recv_with_timeout: couldn't parse "
+                                "line as json\n");
+                free(line_result.line);
+                exit(EXIT_FAILURE);
+            }
+
+            free(line_result.line);
+            msg_result.result = INPUT_READ_SUCCESS;
+            msg_result.msg = msg;
+            return msg_result;
+        }
+        default:
+        {
+            fprintf(stderr,
+                    "Error: msg_recv_with_timeout: invalid line_result\n");
+            exit(EXIT_FAILURE);
         }
     }
 }
 
 json_object* msg_recv()
 {
-    char* input_line = NULL;
-    size_t input_len = 0;
-    // HACK: Using a default timeout; parameterizing msg_recv is a TODO.
-    struct timeval timeout = DEFAULT_TIMEOUT_TIMEVAL;
+    // NOTE: Passing NULL for timeout means we never timeout.
+    msg_recv_result_t result = msg_recv_with_timeout(NULL);
 
-    long long input_bytes_read =
-        getline_with_timeout(&input_line, &input_len, timeout);
-    if (input_bytes_read == INPUT_READ_EOF)
+    switch (result.result)
     {
-        return NULL;
-    }
-    // TODO: What to do if we get a timeout?
-    else if (input_bytes_read == INPUT_READ_TIMEDOUT)
-    {
-        // BUG: We have two different semantics for NULL pointer!
-        return NULL;
-    }
-    else
-    {
-        json_object* msg = json_tokener_parse(input_line);
-        if (msg == NULL)
+        case (INPUT_READ_EOF):
         {
-            fprintf(stderr, "Error: msg_recv: couldn't parse line as json\n");
-            free(input_line);
+            return NULL;
+        }
+        case (INPUT_READ_SUCCESS):
+        {
+            return result.msg;
+        }
+        // NOTE: This case should never happen.
+        case (INPUT_READ_TIMEDOUT):
+        {
+            fprintf(stderr, "Error: msg_recv: timed out waiting for input\n");
             exit(EXIT_FAILURE);
         }
-
-        free(input_line);
-        return msg;
+        default:
+        {
+            fprintf(stderr, "Error: msg_recv: invalid result\n");
+            exit(EXIT_FAILURE);
+        }
     }
 }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -1,4 +1,5 @@
 #include "util.h"
+#include "json-c/json_object.h"
 
 #include <errno.h>
 #include <stdint.h>
@@ -38,7 +39,7 @@ json_object* msg_recv()
     json_object* msg = json_tokener_parse(input_line);
     if (msg == NULL)
     {
-        fprintf(stderr, "Error: recv_msg: couldn't parse line as json");
+        fprintf(stderr, "Error: recv_msg: couldn't parse line as json\n");
         free(input_line);
         exit(EXIT_FAILURE);
     }
@@ -95,6 +96,42 @@ const char* node_id(json_object* init_msg)
     json_object* body = json_object_object_get(init_msg, "body");
     json_object* node_id = json_object_object_get(body, "node_id");
     return json_object_get_string(node_id);
+}
+
+const char** node_ids(json_object* init_msg)
+{
+    json_object* body = json_object_object_get(init_msg, "body");
+    json_object* node_ids = json_object_object_get(body, "node_ids");
+    if (json_object_get_type(node_ids) != json_type_array)
+    {
+        fprintf(stderr, "Error: node_ids: node_ids is not an array\n");
+        exit(EXIT_FAILURE);
+    }
+    size_t array_length = json_object_array_length(node_ids);
+    const char** peers = malloc(sizeof(char*) * array_length);
+    for (size_t i = 0; i < array_length; i++)
+    {
+        json_object* node_id = json_object_array_get_idx(node_ids, i);
+        if (json_object_get_type(node_id) != json_type_string)
+        {
+            fprintf(stderr, "Error: node_ids: node_id is not a string\n");
+            exit(EXIT_FAILURE);
+        }
+        peers[i] = json_object_get_string(node_id);
+    }
+    return peers;
+}
+
+const size_t node_ids_count(json_object* init_msg)
+{
+    json_object* body = json_object_object_get(init_msg, "body");
+    json_object* node_ids = json_object_object_get(body, "node_ids");
+    if (json_object_get_type(node_ids) != json_type_array)
+    {
+        fprintf(stderr, "Error: node_ids: node_ids is not an array\n");
+        exit(EXIT_FAILURE);
+    }
+    return json_object_array_length(node_ids);
 }
 
 const char* msg_type(json_object* msg)

--- a/lib/util.h
+++ b/lib/util.h
@@ -3,6 +3,12 @@
 #include <json-c/json.h>
 #include <stdint.h>
 
+typedef enum INPUT_READ_RESULTS : long long
+{
+    INPUT_READ_TIMEDOUT = -1LL,
+    INPUT_READ_EOF = -2LL,
+} INPUT_READ_RESULTS;
+
 // "Takes ownership" of the input object (this function will call `put`).
 void msg_send(json_object* msg);
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -3,11 +3,26 @@
 #include <json-c/json.h>
 #include <stdint.h>
 
-typedef enum INPUT_READ_RESULTS : long long
+typedef enum INPUT_READ_RESULTS
 {
-    INPUT_READ_TIMEDOUT = -1LL,
-    INPUT_READ_EOF = -2LL,
+    INPUT_READ_SUCCESS = 0,
+    INPUT_READ_TIMEDOUT = -1,
+    INPUT_READ_EOF = 2,
 } INPUT_READ_RESULTS;
+
+typedef struct msg_recv_result
+{
+    INPUT_READ_RESULTS result;
+    json_object* msg;
+} msg_recv_result_t;
+
+// Input line is owned if successful result is returned.
+typedef struct getline_result
+{
+    INPUT_READ_RESULTS result;
+    char* line;
+    size_t line_len;
+} getline_result_t;
 
 // "Takes ownership" of the input object (this function will call `put`).
 void msg_send(json_object* msg);
@@ -15,6 +30,10 @@ void msg_send(json_object* msg);
 // Returns an "owned" object (the caller must eventually call `put`).
 // Returns NULL if there are no more messages.
 json_object* msg_recv();
+
+// Returns an "owned" object (the caller must eventually call `put`), when
+// result is INPUT_READ_SUCCESS.
+msg_recv_result_t msg_recv_with_timeout(struct timeval* timeout);
 
 // Returns an "owned" object (the caller must eventually call `put`).
 // Merely "borrows" the input object -- ownership stays with the caller.

--- a/lib/util.h
+++ b/lib/util.h
@@ -20,11 +20,13 @@ json_object* generic_reply(json_object* msg);
 const char* node_id(json_object* init_msg);
 
 // Borrows init_msg.
-// The returned array of strings is owned by the caller.
+// The returned array is owned by the caller, and must be freed.
+// The strings in the array are borrowed from init_msg; do not use them after
+// freeing init_msg.
 const char** node_ids(json_object* init_msg);
 
 // Borrows init_msg.
-const size_t node_ids_count(json_object* init_msg);
+size_t node_ids_count(json_object* init_msg);
 
 // Borrows msg.
 // The returned string is borrowed from msg; don't use it after freeing msg.

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,24 +1,30 @@
 #pragma once
 
-#include <stdint.h>
 #include <json-c/json.h>
+#include <stdint.h>
 
 // "Takes ownership" of the input object (this function will call `put`).
 void msg_send(json_object* msg);
 
 // Returns an "owned" object (the caller must eventually call `put`).
-//
 // Returns NULL if there are no more messages.
 json_object* msg_recv();
 
 // Returns an "owned" object (the caller must eventually call `put`).
-//
 // Merely "borrows" the input object -- ownership stays with the caller.
 json_object* generic_reply(json_object* msg);
 
 // Borrows init_msg.
-// The returned string is borrowed from init_msg; don't use it after freeing init_msg.
+// The returned string is borrowed from init_msg; don't use it after freeing
+// init_msg.
 const char* node_id(json_object* init_msg);
+
+// Borrows init_msg.
+// The returned array of strings is owned by the caller.
+const char** node_ids(json_object* init_msg);
+
+// Borrows init_msg.
+const size_t node_ids_count(json_object* init_msg);
 
 // Borrows msg.
 // The returned string is borrowed from msg; don't use it after freeing msg.

--- a/notes/2023-08-05.md
+++ b/notes/2023-08-05.md
@@ -10,7 +10,7 @@
 
 We are going to implement a general `reliable_send` / `reliable_recv` framework such that every node has access to this API relative to every other node in the network.
 
-In our applicaiton code, we just need to switch `msg_send` and `msg_recv` out for `reliable_send` and `reliable_recv`, respectively, in the handlers / dispatchers.
+In our application code, we just need to switch `msg_send` and `msg_recv` out for `reliable_send` and `reliable_recv`, respectively, in the handlers / dispatchers.
 
 ### Any Node
 

--- a/notes/2023-08-08.md
+++ b/notes/2023-08-08.md
@@ -1,0 +1,48 @@
+# Dev Notes
+
+2023-08-08
+
+## Accomplishments 🏆
+
+- Review dictionary implementation together; minor enhancements to `collections.c`
+- Broke ground on `tcp.{c,h}`
+
+## Recap ⏪
+
+**`msg_send_pusher` Steps**
+
+1. Append new message to tail of queue
+
+**`msg_recv_listener` Steps**
+
+Event loop that only returns when a _new data_ message is received.
+Until then:
+
+- It is "ACK"-ing _data_ messages it's already seen
+- Incoming "ACK"s:
+  - If incoming "ACK" sequence index matches the sequence index at the head of the sending queue, dequeue from sending queue
+  - If incoming "ACK" sequence index _doesn't_ match the sequence index at the head of the sending queue, noop
+
+### ACK schema
+
+```json
+{
+  "src": "us",
+  "dest": "them",
+  "body": { "type": "ACK", "seq_msg_index": 0 }
+}
+```
+
+## TODOs 📝
+
+- [ ] **Kevan**: Look at Github Issues for more info
+- [ ] **Kevan**: Refactor json obj creation dup'd code (`generate_ACK_msg`)
+- [ ] **Kevan**: Test the current two-node impl, using mael's echo workload
+- [ ] **Ravi**: Work on dictionary TODOs
+
+### Backlog
+
+- Generalize single-channel framework (`tcp.c`) to arbitrary number of pairwise relationships:
+  - Each instance/node keeps a hashtable of channels (keyed on `node_id`)
+  - For msgs pushed via reliable_send, look at the dest field, and lookup that channel state
+  - For msgs we recv, look at the src field, and use the corresponding state

--- a/notes/2023-08-30.md
+++ b/notes/2023-08-30.md
@@ -1,0 +1,19 @@
+# Dev Notes
+
+2023-08-30
+
+## Accomplishments 🏆
+
+- Fix index types (using `ssize_t` for indexing into our collections)
+- Add `msg_send` calls to `msg_recv_listener` to _actually_ send messages between nodes
+
+## Recap ⏪
+
+## TODOs 📝
+
+- [ ] **Kevan**:
+- [ ] **Ravi**:
+
+### Backlog
+
+-

--- a/src/challenge-1/challenge-1.c
+++ b/src/challenge-1/challenge-1.c
@@ -1,6 +1,6 @@
+#include <json-c/json.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <json-c/json.h>
 #include <stdlib.h>
 
 #include "../../lib/util.h"
@@ -11,8 +11,9 @@ json_object* echo_reply(json_object* echo_msg);
 int main()
 {
     json_object* init_msg = msg_recv();
-    if (init_msg == NULL) {
-        fprintf(stderr, "expected init message, got EOF");
+    if (init_msg == NULL)
+    {
+        fprintf(stderr, "expected init message, got EOF\n");
         exit(EXIT_FAILURE);
     }
     msg_send(init_reply(init_msg));
@@ -36,9 +37,11 @@ json_object* echo_reply(json_object* echo_msg)
     json_object* reply = generic_reply(echo_msg);
 
     // reply.body.echo = echo_msg.body.echo
-    json_object* reply_echo = json_object_object_get(json_object_object_get(echo_msg, "body"), "echo");
+    json_object* reply_echo = json_object_object_get(
+        json_object_object_get(echo_msg, "body"), "echo");
     json_object_get(reply_echo);
-    json_object_object_add(json_object_object_get(reply, "body"), "echo", reply_echo);
+    json_object_object_add(json_object_object_get(reply, "body"), "echo",
+                           reply_echo);
 
     return reply;
 }

--- a/src/challenge-1/challenge-1.c
+++ b/src/challenge-1/challenge-1.c
@@ -13,7 +13,7 @@ int main()
     json_object* init_msg = msg_recv();
     if (init_msg == NULL)
     {
-        fprintf(stderr, "expected init message, got EOF\n");
+        fprintf(stderr, "Error: expected init message, got EOF\n");
         exit(EXIT_FAILURE);
     }
     msg_send(init_reply(init_msg));

--- a/src/challenge-1/challenge-1.c
+++ b/src/challenge-1/challenge-1.c
@@ -27,11 +27,15 @@ int main()
     }
 }
 
+// Borrows `init_msg`.
+// Returns an owned object.
 json_object* init_reply(json_object* init_msg)
 {
     return generic_reply(init_msg);
 }
 
+// Borrows `echo_msg`.
+// Returns an owned object.
 json_object* echo_reply(json_object* echo_msg)
 {
     json_object* reply = generic_reply(echo_msg);

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -24,7 +24,7 @@ int main(void)
     json_object* init_msg = msg_recv();
     if (init_msg == NULL)
     {
-        fprintf(stderr, "expected init message, got EOF\n");
+        fprintf(stderr, "Error: expected init message, got EOF\n");
         exit(EXIT_FAILURE);
     }
     bool is_leader = strcmp(node_id(init_msg), LEADER_NODE) == 0;

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -136,9 +136,7 @@ void leader_event_loop()
 }
 
 // Helper function for using `json_object`s in a `Queue`.
-void queue_json_object_free(void* obj) {
-    json_object_put(obj);
-}
+void queue_json_object_free(void* obj) { json_object_put(obj); }
 
 // Used exclusively by Leader
 // Takes ownership of `conch_request`.

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -12,10 +12,7 @@ const char* const LEADER_NODE = "n0";
 
 void follower_event_loop();
 void leader_event_loop();
-const char* node_id(json_object* init_msg);
-const char* msg_type(json_object* msg);
-json_object* init_reply(json_object* init_msg);
-
+void queue_json_object_free(void* obj);
 void client_request_handler(json_object* client_request);
 void conch_response_handler(json_object* conch_response);
 void conch_request_handler(json_object* conch_request, Queue* conch_queue);
@@ -34,7 +31,7 @@ int main(void)
     const char** peers = node_ids(init_msg);
     const size_t num_peers = node_ids_count(init_msg);
     tcp_init(peers, num_peers);
-    msg_send(init_reply(init_msg));
+    msg_send(generic_reply(init_msg));
     json_object_put(init_msg);
     if (is_leader)
     {
@@ -45,6 +42,7 @@ int main(void)
         follower_event_loop();
     }
     tcp_free(peers, num_peers);
+    free(peers);
 }
 
 void follower_event_loop()
@@ -76,30 +74,33 @@ void follower_event_loop()
 
 void leader_event_loop()
 {
-    Queue* queue = queue_init(5);
+    Queue* conch_request_queue = queue_init(5, queue_json_object_free);
     Conch* conch = conch_init(0);
 
     json_object* msg;
     while (true)
     {
         // Serve conch requests as the conch becomes available.
-        if (!queue_is_empty(queue) && conch_is_available(conch))
+        if (!queue_is_empty(conch_request_queue) && conch_is_available(conch))
         {
-            conch_response_dispatcher(conch, queue);
+            conch_response_dispatcher(conch, conch_request_queue);
             continue;
         }
 
         if ((msg = msg_recv()) == NULL)
         {
-            // If the conch is still loaned out, we won't get it back, since
-            // stdin is EOF.
-            if (!queue_is_empty(queue))
+            // If the conch is still loaned out, we'll never get it back, since
+            // there are no more incoming messages.
+            if (!conch_is_available(conch))
             {
-                assert(!conch_is_available(conch));
                 fprintf(stderr, "Warn: leader_event_loop: shut down with "
-                                "unserved conch requests\n");
+                                "unreturned conch\n");
             }
-            break;
+
+            // Shutdown.
+            queue_free(conch_request_queue);
+            conch_free(conch);
+            return;
         }
 
         // Handle incoming messages.
@@ -126,23 +127,22 @@ void leader_event_loop()
                 stderr,
                 "Error: leader_event_loop: unrecognized message type: \"%s\"\n",
                 type);
-            queue_free(queue);
+            queue_free(conch_request_queue);
             conch_free(conch);
             free(msg);
             exit(EXIT_FAILURE);
         }
     }
-
-    queue_free(queue);
-    conch_free(conch);
 }
 
-json_object* init_reply(json_object* init_msg)
-{
-    return generic_reply(init_msg);
+// Helper function for using `json_object`s in a `Queue`.
+void queue_json_object_free(void* obj) {
+    json_object_put(obj);
 }
 
 // Used exclusively by Leader
+// Takes ownership of `conch_request`.
+// Borrows `request_queue`.
 void conch_request_handler(json_object* conch_request, Queue* request_queue)
 {
     if (queue_is_full(request_queue))
@@ -154,14 +154,15 @@ void conch_request_handler(json_object* conch_request, Queue* request_queue)
     json_object* body = json_object_object_get(conch_request, "body");
     json_object* original_client_request =
         json_object_object_get(body, "original_client_request");
-    queue_enqueue(request_queue, original_client_request);
     json_object_get(original_client_request);
+    queue_enqueue(request_queue, original_client_request);
 
     // Clean up: Free conch request message
     json_object_put(conch_request);
 }
 
-// Used exclusively by Leader
+// Used exclusively by Leader.
+// Borrows `conch` and `request_queue`.
 void conch_response_dispatcher(Conch* conch, Queue* request_queue)
 {
     if (!conch_is_available(conch))
@@ -202,6 +203,8 @@ void conch_response_dispatcher(Conch* conch, Queue* request_queue)
 }
 
 // Used exclusively by Leader
+// Takes ownership of `conch_release`.
+// Borrows `conch`.
 void conch_release_handler(json_object* conch_release, Conch* conch)
 {
     json_object* body = json_object_object_get(conch_release, "body");
@@ -213,6 +216,7 @@ void conch_release_handler(json_object* conch_release, Conch* conch)
     json_object_put(conch_release);
 }
 
+// Takes ownership of `client_request`.
 void client_request_handler(json_object* client_request)
 {
     json_object* conch_request = json_object_new_object();
@@ -239,6 +243,7 @@ void client_request_handler(json_object* client_request)
     json_object_put(client_request);
 }
 
+// Takes ownership of `conch_response`.
 void conch_response_handler(json_object* conch_response)
 {
     // Construct client response message

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -115,7 +115,7 @@ void leader_event_loop()
         }
         else if (strcmp(type, "conch_request") == 0)
         {
-            conch_request_handler(msg, queue);
+            conch_request_handler(msg, conch_request_queue);
         }
         else if (strcmp(type, "conch_release") == 0)
         {

--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -41,7 +41,7 @@ int main(void)
     {
         follower_event_loop();
     }
-    tcp_free(peers, num_peers);
+    tcp_free();
     free(peers);
 }
 

--- a/tests/lib/tcp-test.c
+++ b/tests/lib/tcp-test.c
@@ -22,12 +22,12 @@ int main()
 
     const char** peers = node_ids(init_msg);
     size_t num_peers = node_ids_count(init_msg);
-    // tcp_init(peers, num_peers);
+    tcp_init(peers, num_peers);
 
     msg_send(generic_reply(init_msg));
 
     json_object* msg;
-    while ((msg = msg_recv()) != NULL)
+    while ((msg = msg_recv_listener()) != NULL)
     {
         const char* type = msg_type(msg);
         if (strcmp(type, "echo") == 0) {
@@ -49,7 +49,7 @@ int main()
         }
     }
 
-    // tcp_free(peers, num_peers);
+    tcp_free(peers, num_peers);
     json_object_put(init_msg);
 }
 
@@ -70,7 +70,7 @@ void ping_random_peer(json_object* original_msg, const char** peers, size_t num_
     // Include the original message as a payload.
     json_object_object_add(body, "original_msg", original_msg);
 
-    msg_send(ping);
+    msg_send_pusher(ping);
 }
 
 // Takes ownership of `ping`.
@@ -88,7 +88,7 @@ void pong(json_object* ping) {
     json_object_put(ping);
     json_object_object_add(pong_body, "original_msg", original_msg);
 
-    msg_send(pong);
+    msg_send_pusher(pong);
 }
 
 // Takes ownership of `echo_request`.

--- a/tests/lib/tcp-test.c
+++ b/tests/lib/tcp-test.c
@@ -1,0 +1,110 @@
+#include <json-c/json.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../lib/util.h"
+#include "../../lib/tcp.h"
+
+void ping_random_peer(json_object* original_msg, const char** peers, size_t num_peers);
+void pong(json_object* ping);
+void echo(json_object* echo_request);
+
+int main()
+{
+    json_object* init_msg = msg_recv();
+    if (init_msg == NULL)
+    {
+        fprintf(stderr, "expected init message, got EOF\n");
+        exit(EXIT_FAILURE);
+    }
+
+    const char** peers = node_ids(init_msg);
+    size_t num_peers = node_ids_count(init_msg);
+    // tcp_init(peers, num_peers);
+
+    msg_send(generic_reply(init_msg));
+
+    json_object* msg;
+    while ((msg = msg_recv()) != NULL)
+    {
+        const char* type = msg_type(msg);
+        if (strcmp(type, "echo") == 0) {
+            ping_random_peer(msg, peers, num_peers);
+        } else if (strcmp(type, "ping") == 0) {
+            pong(msg);
+        } else if (strcmp(type, "pong") == 0) {
+            // Extract the original message
+            json_object* body = json_object_object_get(msg, "body");
+            json_object* orig = json_object_object_get(body, "original_msg");
+            json_object_get(orig);
+            json_object_put(msg);
+
+            // Reply to the original client.
+            echo(orig);
+        } else {
+            fprintf(stderr, "invalid incoming message type: %s\n", type);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    // tcp_free(peers, num_peers);
+    json_object_put(init_msg);
+}
+
+// Takes ownership of original_msg. Borrows `peers`.
+void ping_random_peer(json_object* original_msg, const char** peers, size_t num_peers) {
+    json_object* ping = generic_reply(original_msg);
+
+    // Choose a random peer (possibly myself!)
+    int i = rand() % num_peers;
+    json_object* dest = json_object_new_string(peers[i]);
+    json_object_object_add(ping, "dest", dest);
+
+    // type = "ping"
+    json_object* body = json_object_object_get(ping, "body");
+    json_object* type = json_object_new_string("ping");
+    json_object_object_add(body, "type", type);
+
+    // Include the original message as a payload.
+    json_object_object_add(body, "original_msg", original_msg);
+
+    msg_send(ping);
+}
+
+// Takes ownership of `ping`.
+void pong(json_object* ping) {
+    // Create a "pong" message.
+    json_object* pong = generic_reply(ping);
+    json_object* pong_body = json_object_object_get(pong, "body");
+    json_object* type = json_object_new_string("pong");
+    json_object_object_add(pong_body, "type", type);
+
+    // Clone the payload.
+    json_object* ping_body = json_object_object_get(ping, "body");
+    json_object* original_msg = json_object_object_get(ping_body, "original_msg");
+    json_object_get(original_msg);
+    json_object_put(ping);
+    json_object_object_add(pong_body, "original_msg", original_msg);
+
+    msg_send(pong);
+}
+
+// Takes ownership of `echo_request`.
+void echo(json_object* echo_request)
+{
+    json_object* reply = generic_reply(echo_request);
+
+    // payload = echo_request.body.echo
+    json_object* req_body = json_object_object_get(echo_request, "body");
+    json_object* payload = json_object_object_get(req_body, "echo");
+    json_object_get(payload);
+    json_object_put(echo_request);
+
+    // reply.body.echo = payload
+    json_object* reply_body = json_object_object_get(reply, "body");
+    json_object_object_add(reply_body, "echo", payload);
+
+    msg_send(reply);
+}

--- a/tests/lib/tcp-test.c
+++ b/tests/lib/tcp-test.c
@@ -8,7 +8,7 @@
 #include "../../lib/util.h"
 
 void ping_random_peer(json_object* original_msg, const char** peers,
-                      size_t num_peers);
+                      size_t num_peers, const char* self);
 void pong(json_object* ping);
 void echo(json_object* echo_request);
 
@@ -24,7 +24,7 @@ int main()
     const char** peers = node_ids(init_msg);
     size_t num_peers = node_ids_count(init_msg);
     tcp_init(peers, num_peers);
-
+    const char* self = node_id(init_msg);
     msg_send(generic_reply(init_msg));
 
     json_object* msg;
@@ -33,7 +33,7 @@ int main()
         const char* type = msg_type(msg);
         if (strcmp(type, "echo") == 0)
         {
-            ping_random_peer(msg, peers, num_peers);
+            ping_random_peer(msg, peers, num_peers, self);
         }
         else if (strcmp(type, "ping") == 0)
         {
@@ -61,14 +61,23 @@ int main()
     json_object_put(init_msg);
 }
 
-// Takes ownership of original_msg. Borrows `peers`.
+// Takes ownership of original_msg. Borrows `peers` and `self`.
 void ping_random_peer(json_object* original_msg, const char** peers,
-                      size_t num_peers)
+                      size_t num_peers, const char* self)
 {
     json_object* ping = generic_reply(original_msg);
 
-    // Choose a random peer (possibly myself!)
-    int i = rand() % num_peers;
+    // Choose a random peer (not myself)
+    int i;
+    if (num_peers == 1)
+    {
+        fprintf(stderr, "Error: ping_random_peer: only one peer\n");
+        exit(EXIT_FAILURE);
+    }
+    do
+    {
+        i = rand() % num_peers;
+    } while (strcmp(peers[i], self) == 0);
     json_object* dest = json_object_new_string(peers[i]);
     json_object_object_add(ping, "dest", dest);
 

--- a/tests/lib/tcp-test.c
+++ b/tests/lib/tcp-test.c
@@ -17,7 +17,7 @@ int main()
     json_object* init_msg = msg_recv();
     if (init_msg == NULL)
     {
-        fprintf(stderr, "expected init message, got EOF\n");
+        fprintf(stderr, "Error: expected init message, got EOF\n");
         exit(EXIT_FAILURE);
     }
 
@@ -52,7 +52,7 @@ int main()
         }
         else
         {
-            fprintf(stderr, "invalid incoming message type: %s\n", type);
+            fprintf(stderr, "Error: invalid incoming message type: %s\n", type);
             exit(EXIT_FAILURE);
         }
     }

--- a/tests/lib/tcp-test.c
+++ b/tests/lib/tcp-test.c
@@ -4,10 +4,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../lib/util.h"
 #include "../../lib/tcp.h"
+#include "../../lib/util.h"
 
-void ping_random_peer(json_object* original_msg, const char** peers, size_t num_peers);
+void ping_random_peer(json_object* original_msg, const char** peers,
+                      size_t num_peers);
 void pong(json_object* ping);
 void echo(json_object* echo_request);
 
@@ -30,11 +31,16 @@ int main()
     while ((msg = msg_recv_listener()) != NULL)
     {
         const char* type = msg_type(msg);
-        if (strcmp(type, "echo") == 0) {
+        if (strcmp(type, "echo") == 0)
+        {
             ping_random_peer(msg, peers, num_peers);
-        } else if (strcmp(type, "ping") == 0) {
+        }
+        else if (strcmp(type, "ping") == 0)
+        {
             pong(msg);
-        } else if (strcmp(type, "pong") == 0) {
+        }
+        else if (strcmp(type, "pong") == 0)
+        {
             // Extract the original message
             json_object* body = json_object_object_get(msg, "body");
             json_object* orig = json_object_object_get(body, "original_msg");
@@ -43,18 +49,22 @@ int main()
 
             // Reply to the original client.
             echo(orig);
-        } else {
+        }
+        else
+        {
             fprintf(stderr, "invalid incoming message type: %s\n", type);
             exit(EXIT_FAILURE);
         }
     }
 
-    tcp_free(peers, num_peers);
+    tcp_free();
     json_object_put(init_msg);
 }
 
 // Takes ownership of original_msg. Borrows `peers`.
-void ping_random_peer(json_object* original_msg, const char** peers, size_t num_peers) {
+void ping_random_peer(json_object* original_msg, const char** peers,
+                      size_t num_peers)
+{
     json_object* ping = generic_reply(original_msg);
 
     // Choose a random peer (possibly myself!)
@@ -74,7 +84,8 @@ void ping_random_peer(json_object* original_msg, const char** peers, size_t num_
 }
 
 // Takes ownership of `ping`.
-void pong(json_object* ping) {
+void pong(json_object* ping)
+{
     // Create a "pong" message.
     json_object* pong = generic_reply(ping);
     json_object* pong_body = json_object_object_get(pong, "body");
@@ -83,7 +94,8 @@ void pong(json_object* ping) {
 
     // Clone the payload.
     json_object* ping_body = json_object_object_get(ping, "body");
-    json_object* original_msg = json_object_object_get(ping_body, "original_msg");
+    json_object* original_msg =
+        json_object_object_get(ping_body, "original_msg");
     json_object_get(original_msg);
     json_object_put(ping);
     json_object_object_add(pong_body, "original_msg", original_msg);

--- a/tests/memcheck_challenge-2.sh
+++ b/tests/memcheck_challenge-2.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+BUILD_DIR="/app/build"
+
+# This is a thin wrapper around challenge-2 binary so we can use valgrind with maelstrom
+valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes $BUILD_DIR/challenge-2.out

--- a/tests/memcheck_tcp-test.sh
+++ b/tests/memcheck_tcp-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+BUILD_DIR="/app/build"
+
+# This is a thin wrapper around tcp-test binary so we can use valgrind with maelstrom
+valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes $BUILD_DIR/tcp-test.out


### PR DESCRIPTION
# Overview

We upgrade the network to *reliable links* in a system model that is partially asynchronous by introducing a framework that takes inspiration from the Transmission Control Protocol (TCP). In particular, this framework introduces the ability to have arbitrary pairwise node communications in the presence of \[temporary] network partitions by retrying/deduping messages accordingly (i.e., retry timeouts and not delivering duplicated messages to the application).

This bulk of this new functionality lives in `tcp.{c,h}`, but important changes were made to the library code to enable the underlying architecture and make sure that framework did not introduce breaking changes to existing send and receive mechanisms.

## Additional Detail

### The Messages

Each inter-node `Message` contains a JSON payload (`msg`) and a unique integer identifier corresponding to the message (`msg_seq_index`). There are two types of messages that are communicated between nodes: *data* messages and *acknowledgement* messages (i.e., those having the "ACK" type per Maelstrom) .

The former carries relevant information for the operation of the system in its payload, whereas the latter simply acknowledges receipt of some earlier data message.

### The Machinery

Every node is equipped with a dictionary mapping node names (`peer`s; a node is a peer of itself) to `ChannelState`s. A given `ChannelState` (for a `peer`) manages the pairwise send and receive "states" with that `peer`. 

#### Send State

This consists of the following:

-  A message queue, `send_queue`, containing messages to be transmitted over the network
    - Only the `Message` at the head of the `send_queue` is transmitted over the network; only when acknowledgement (an `ACK`-type message) of the receipt of the `Message` at the head of the queue is received, is the head popped off the queue.
-  A send sequence number, `next_send_msg_seq_index`, an integer that is incremented on every unique `Message` to be sent
    - This sequence number defines the `msg_seq_index` to be attached to the next `Message` that is to be sent over the network and it is this integer that the corresponding acknowledgement will have (in `body.seq_msg_index`).
-  A timestamp, `last_head_sent`, indicating the last time a message was transmitted over the network
    - This is used by the network layer to determine whether a retry is needed (i.e., acknowledgement not received within timeout period) or not.

#### Receive State

We only keep an integer (`expected_recv_msg_seq_index`) that reflects the total number of *data* messages that have been delivered to the application. Once the most recent data message is delivered to the application, this number is incremented (in anticipation of the receipt of the subsequent data message, whose `seq_msg_idx` number should match `expected_recv_msg_seq_index`).

### The Interface

- `tcp_init` sets up "The Machinery" (as described above)
- `tcp_free` handles freeing the heap-allocated memory required for the above
- `msg_send_pusher` (the "reliable" analogue of `msg_send`) takes a request from the application to send a message and constructs the `Message` and adds it to the appropriate`send_queue` based on the destination of the message
- `msg_recv_listener` (the "reliable" analogue of `msg_recv`) executes the sending of head-of-`send_queue` messages and handles data and acknowledgement messages accordingly

## Tests

Thanks to @khollbach , we were able to test this using `tests/lib/tcp-test.c`; this testing uncovered [the issue regarding duplicate self-messages](https://github.com/khollbach/gossip-glomers-c/pull/10#discussion_r1311831835).

Additional "testing" was done on the single-leader (conch-forward 🤣 ) approach to Challenge 2. All testing included checking for memory leaks with the aid of `maelstrom` and wrapping our executables with `valgrind` in the shell scripts in the `tests/` directory.

## Feedback Desired

- Does this PR accurately reflect the expected behavior of our code?
- **Bonus points**: Make sure in-line commentary properly reflects "ownership" of objects.

## Breaking Changes

N/A