### PR TITLE
(quickfix) Add delimiter to Challenge 2 unique IDs

### DIFF
--- a/src/challenge-2/challenge-2.c
+++ b/src/challenge-2/challenge-2.c
@@ -43,11 +43,15 @@ json_object* uniq_id_reply(json_object* uniq_id_msg, const char* node_id,
 
     json_object* reply_uniq_id;
 
-    // Construct the unique id (node ID + logical timestamp)
+    // Stringify the logical timestamp
     char logical_timestamp[MAX_SIGNED_INT64_STRLEN + 1];
     sprintf(logical_timestamp, "%ld", (*logical_clock)++);
-    char uniq_id[strlen(node_id) + strlen(logical_timestamp) + 1];
-    strcat(stpcpy(uniq_id, node_id), logical_timestamp);
+
+    // Construct the unique id (node ID + logical timestamp)
+    char uniq_id[strlen(node_id) + strlen(logical_timestamp) + 2];
+    strcpy(uniq_id, node_id);
+    strcat(uniq_id, ":");
+    strcat(uniq_id, logical_timestamp);
 
     reply_uniq_id = json_object_new_string(uniq_id);
     json_object_object_add(json_object_object_get(reply, "body"), "id",


### PR DESCRIPTION
This PR simple adds a `:` delimiter between the `node_id` and the logical timestamp (of the server reply event) so that larger workloads do not cause duplicate identifiers (e.g., is `n234` the 34th event at `n2` or the 4th event at `n23`?).